### PR TITLE
Remove references to "Azure IoT Manager", replace with "IoT Manager"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2021 Northern.tech AS
+Copyright 2022 Northern.tech AS
 
 All content in this project is licensed under the Apache License v2, unless
 indicated otherwise.

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -1,6 +1,6 @@
 #
 # Apache-2.0
-b4acfcfa2a0ba1a8c82ec3965fbcee886cff8394ca4214e0ddac0a36beb1e05a  LICENSE
+1033348db7606a7e61b6484f293847cf8d7a35766efebb97e304d4bd5d7f3f6b  LICENSE
 3eb823230e5d112e1bd032ccc82ae765cf676d0d6d46a1a1daa2d658b3005b67  vendor/github.com/mendersoftware/go-lib-micro/LICENSE
 c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4  vendor/github.com/modern-go/concurrent/LICENSE
 c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4  vendor/github.com/modern-go/reflect2/LICENSE

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/mendersoftware/iot-manager)](https://goreportcard.com/report/github.com/mendersoftware/iot-manager)
 [![Docker pulls](https://img.shields.io/docker/pulls/mendersoftware/iot-manager.svg?maxAge=3600)](https://hub.docker.com/r/mendersoftware/iot-manager/)
 
-Mender: Azure IoT Manager: use Azure IoT with Mender
-=============================
+Mender: IoT Manager: use IoT Cloud platforms with Mender
+========================================================
 
 ## General
 
@@ -12,7 +12,7 @@ Mender is an open source over-the-air (OTA) software updater for embedded Linux
 devices. Mender comprises a client running at the embedded device, as well as
 a server that manages deployments across many devices.
 
-This repository contains the Azure IoT Manager microservice, which is part
+This repository contains the IoT Manager microservice, which is part
 of the Mender server. The Mender server is designed as a microservices architecture
 and comprises several repositories.
 
@@ -28,7 +28,7 @@ repositories to be built to be fully functional. If you are testing the Mender s
 is therefore easier to follow the getting started section above as it integrates these
 services.
 
-If you would like to build the Azure IoT Manager microservice independently, you can follow
+If you would like to build the IoT Manager microservice independently, you can follow
 these steps:
 
 ```

--- a/docs/internal_api.yml
+++ b/docs/internal_api.yml
@@ -1,9 +1,9 @@
 openapi: 3.0.3
 
 info:
-  title: Azure Iot Manager
+  title: IoT Manager
   description: |
-    Internal API for managing devices on Azure IoT Hub.
+    Internal API for managing IoT Cloud integrations.
 
   version: "1"
 

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ func doMain(args []string) {
 			},
 		},
 	}
-	app.Usage = "Azure IoT Manager"
+	app.Usage = "IoT Manager"
 	app.Action = cmdServer
 
 	app.Before = func(args *cli.Context) error {

--- a/server/server.go
+++ b/server/server.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ func InitAndRun(conf config.Reader, dataStore store.DataStore) error {
 		Handler: router,
 	}
 
-	l.Info("Azure IoT Manager service starting up")
+	l.Info("IoT Manager service starting up")
 	l.Infof("listening on %s", listen)
 
 	go func() {


### PR DESCRIPTION
Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>

See, for example: https://staging.docs.mender.io/api/development/#internal-api-azure-iot-manager