### PR TITLE
feat: mask the SharedAccessKey in the connection string (MEN-5386)

### DIFF
--- a/api/http/management_test.go
+++ b/api/http/management_test.go
@@ -77,6 +77,7 @@ func GenerateJWT(id identity.Identity) string {
 
 func TestGetIntegrations(t *testing.T) {
 	t.Parallel()
+	validConnStringString, _ := validConnString.MarshalText()
 	testCases := []struct {
 		Name string
 
@@ -120,7 +121,7 @@ func TestGetIntegrations(t *testing.T) {
 				"provider": model.ProviderIoTHub,
 				"credentials": map[string]interface{}{
 					"type":              model.CredentialTypeSAS,
-					"connection_string": validConnString.String(),
+					"connection_string": string(validConnStringString),
 				},
 			}},
 		},
@@ -278,9 +279,9 @@ func TestCreateIntegration(t *testing.T) {
 
 		RequestBody: map[string]interface{}{
 			"provider": model.ProviderIoTHub,
-			"credentials": model.Credentials{
-				Type:             model.CredentialTypeSAS,
-				ConnectionString: validConnString,
+			"credentials": map[string]interface{}{
+				"type":              model.CredentialTypeSAS,
+				"connection_string": validConnString.String(),
 			},
 		},
 		RequestHdrs: http.Header{
@@ -305,9 +306,9 @@ func TestCreateIntegration(t *testing.T) {
 
 		RequestBody: map[string]interface{}{
 			"provider": model.ProviderIoTHub,
-			"credentials": model.Credentials{
-				Type:             model.CredentialTypeSAS,
-				ConnectionString: validConnString,
+			"credentials": map[string]interface{}{
+				"type":              model.CredentialTypeSAS,
+				"connection_string": validConnString.String(),
 			},
 		},
 		RequestHdrs: http.Header{

--- a/model/connection_string_test.go
+++ b/model/connection_string_test.go
@@ -1,0 +1,69 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseConnectionString(t *testing.T) {
+	cs, err := ParseConnectionString(
+		"HostName=mender-test-hub.azure-devices.net;DeviceId=7b478313-de33-4735-bf00-0ebc31851faf;" +
+			"SharedAccessKey=YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=")
+	assert.NoError(t, err)
+	isZero := cs.IsZero()
+	assert.False(t, isZero)
+	err = cs.Validate()
+	assert.NoError(t, err)
+
+	cs, err = ParseConnectionString(
+		"HostName=mender-test-hub.azure-devices.net;DeviceId=7b478313-de33-4735-bf00-0ebc31851faf;" +
+			"SharedAccessKey=YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=")
+	assert.NoError(t, err)
+	isZero = cs.IsZero()
+	assert.False(t, isZero)
+	err = cs.Validate()
+	assert.NoError(t, err)
+
+	_, err = ParseConnectionString("abc")
+	assert.EqualError(t, err, "invalid connectionstring format")
+}
+
+func TestConnectionStringAuthorization(t *testing.T) {
+	cs, err := ParseConnectionString(
+		"HostName=mender-test-hub.azure-devices.net;DeviceId=7b478313-de33-4735-bf00-0ebc31851faf;" +
+			"SharedAccessKey=YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=")
+	assert.NoError(t, err)
+
+	const layout = "Jan 2, 2006 at 3:04pm (MST)"
+	tm, _ := time.Parse(layout, "Feb 4, 2014 at 6:05pm (PST)")
+	token := cs.Authorization(tm)
+	assert.Equal(t, "SharedAccessSignature sr=mender-test-hub.azure-devices.net&sig=PJYYfRCuL4bo5%2BCc%2Flj1L%2F4AShbEuisEcwGiK90fqYk%3D&se=1391537100", token)
+}
+
+func TestConnectionStringMarshalText(t *testing.T) {
+	cs := &ConnectionString{}
+	err := cs.UnmarshalText([]byte(
+		"HostName=mender-test-hub.azure-devices.net;DeviceId=7b478313-de33-4735-bf00-0ebc31851faf;" +
+			"SharedAccessKey=YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE="))
+	assert.NoError(t, err)
+
+	marshalled, err := cs.MarshalText()
+	assert.NoError(t, err)
+	assert.Equal(t, "HostName=mender-test-hub.azure-devices.net;DeviceId=7b478313-de33-4735-bf00-0ebc31851faf;SharedAccessKey=YWFh...<omitted>", string(marshalled))
+}

--- a/tests/tests/test_sync.py
+++ b/tests/tests/test_sync.py
@@ -307,7 +307,7 @@ class TestSync:
                 "body": re.compile(
                     r".*HostName=mock\.azure-devices\.net:8443;"
                     + r"DeviceId=93406e21-8e3f-4435-9786-a294a70298ee;"
-                    + r"SharedAccessKey=secret64.*"
+                    + r"SharedAccessKey=secr.*"
                 ),
             },
             "result": {


### PR DESCRIPTION
Connection strings contain shared access keys, which we consider
secrets. For this reason, we do not want to include the key in the JSON
response when listing the integrations. We replace the key with the
first four characters, for identification purposes, concatenated with
the text `...<omitted>`.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>