### PR TITLE
fix: Validate credential types and device policy existence

### DIFF
--- a/api/http/management.go
+++ b/api/http/management.go
@@ -95,16 +95,21 @@ func (h *ManagementHandler) CreateIntegration(c *gin.Context) {
 
 	inserted, err := h.app.CreateIntegration(ctx, integration)
 	if err != nil {
-		switch cause := errors.Cause(err); cause {
-		case app.ErrIntegrationExists:
-			// NOTE: temporary limitation
-			rest.RenderError(c, http.StatusConflict, cause)
-		default:
-			_ = c.Error(err)
-			rest.RenderError(c,
-				http.StatusInternalServerError,
-				err,
-			)
+		var verr *model.ValidationError
+		if errors.As(err, &verr) {
+			rest.RenderError(c, http.StatusBadRequest, err)
+		} else {
+			switch cause := errors.Cause(err); cause {
+			case app.ErrIntegrationExists:
+				// NOTE: temporary limitation
+				rest.RenderError(c, http.StatusConflict, cause)
+			default:
+				_ = c.Error(err)
+				rest.RenderError(c,
+					http.StatusInternalServerError,
+					err,
+				)
+			}
 		}
 		return
 	}

--- a/client/iotcore/mocks/Client.go
+++ b/client/iotcore/mocks/Client.go
@@ -67,6 +67,29 @@ func (_m *Client) GetDevice(ctx context.Context, creds model.AWSCredentials, dev
 	return r0, r1
 }
 
+// GetDevicePolicy provides a mock function with given fields: ctx, creds, policyName
+func (_m *Client) GetDevicePolicy(ctx context.Context, creds model.AWSCredentials, policyName string) (*iotcore.DevicePolicy, error) {
+	ret := _m.Called(ctx, creds, policyName)
+
+	var r0 *iotcore.DevicePolicy
+	if rf, ok := ret.Get(0).(func(context.Context, model.AWSCredentials, string) *iotcore.DevicePolicy); ok {
+		r0 = rf(ctx, creds, policyName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*iotcore.DevicePolicy)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, model.AWSCredentials, string) error); ok {
+		r1 = rf(ctx, creds, policyName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetDeviceShadow provides a mock function with given fields: ctx, creds, id
 func (_m *Client) GetDeviceShadow(ctx context.Context, creds model.AWSCredentials, id string) (*iotcore.DeviceShadow, error) {
 	ret := _m.Called(ctx, creds, id)

--- a/model/validation.go
+++ b/model/validation.go
@@ -1,0 +1,106 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package model
+
+import (
+	"errors"
+	"strings"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+type ValidationError struct {
+	Field  string
+	Reason error
+}
+
+func (err *ValidationError) Error() string {
+	if err == nil || err.Reason == nil {
+		return ""
+	}
+	if err.Field == "" {
+		return err.Reason.Error()
+	}
+	return err.Field + ": " + err.Reason.Error()
+}
+
+func (err *ValidationError) Unwrap() error {
+	if err == nil {
+		return nil
+	}
+	return err.Reason
+}
+
+func (err *ValidationError) Is(target error) bool {
+	if err == nil {
+		return false
+	}
+	if verr, ok := target.(*ValidationError); ok && verr != nil {
+		if err.Field != verr.Field {
+			return false
+		}
+		return errors.Is(err.Reason, verr.Unwrap())
+	}
+	return errors.Is(err.Reason, target)
+}
+
+type ValidationErrors []*ValidationError
+
+func (errs ValidationErrors) Error() string {
+	if len(errs) <= 0 {
+		return ""
+	}
+	var errMsgs []string = make([]string, len(errs))
+	for i := range errs {
+		errMsgs[i] = errs[i].Error()
+	}
+	return strings.Join(errMsgs, "; ")
+}
+
+func (errs ValidationErrors) Is(err error) bool {
+	for _, verr := range errs {
+		if errors.Is(verr, err) {
+			return true
+		}
+	}
+	return false
+}
+
+func IsValidationError(err error) bool {
+	switch t := err.(type) {
+	case nil:
+		return false
+
+	case *ValidationError:
+		if t == nil {
+			return false
+		}
+
+	case ValidationErrors:
+		if t == nil {
+			return false
+		}
+
+	case validation.Error:
+
+	case validation.Errors:
+		if len(t) == 0 {
+			return false
+		}
+	default:
+		return false
+	}
+	return true
+}

--- a/model/validation_test.go
+++ b/model/validation_test.go
@@ -1,0 +1,89 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package model
+
+import (
+	"errors"
+	"testing"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+var ErrCannotBeEmpty = errors.New("cannot be empty")
+
+func TestValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, IsValidationError(errors.New("generic error")))
+
+	var err *ValidationError
+	assert.False(t, IsValidationError(err))
+	assert.False(t, errors.Is(err, errors.New("generic error")))
+	assert.EqualError(t, err, "")
+	assert.Nil(t, err.Unwrap())
+
+	// Empty ValidationError
+	err = new(ValidationError)
+	assert.EqualError(t, err, "")
+	err.Field = "foo"
+	assert.EqualError(t, err, "")
+
+	// err is now a valid error
+	err.Reason = ErrCannotBeEmpty
+	assert.EqualError(t, err, err.Field+": "+ErrCannotBeEmpty.Error())
+	assert.True(t, IsValidationError(err))
+
+	// Compare underlying error
+	assert.ErrorIs(t, err, ErrCannotBeEmpty)
+
+	// Is compares both Reason and Field
+	assert.ErrorIs(t, err,
+		&ValidationError{Field: "foo", Reason: ErrCannotBeEmpty},
+	)
+	assert.False(t, errors.Is(err,
+		&ValidationError{Field: "bar", Reason: ErrCannotBeEmpty},
+	))
+
+	// Verify nil check
+	assert.False(t, err.Is((*ValidationError)(nil)))
+
+	assert.EqualError(t,
+		&ValidationError{Reason: ErrCannotBeEmpty},
+		ErrCannotBeEmpty.Error(),
+	)
+
+	// Empty ValidationErrors
+	var errs ValidationErrors
+	assert.EqualError(t, errs, "")
+	assert.False(t, IsValidationError(errs))
+
+	// Make ValidationErrors valid
+	errs = append(errs, err)
+	assert.ErrorIs(t, errs, err)
+	assert.ErrorIs(t, errs, ErrCannotBeEmpty)
+	assert.False(t, errors.Is(errs, errors.New("generic error")))
+	assert.EqualError(t, errs, err.Error())
+
+	// Check ozzo validation errors evaluates to ValidationError
+	var ozzoError validation.Error
+	assert.False(t, IsValidationError(ozzoError))
+	ozzoError = validation.NewError("foo", "bar")
+	assert.True(t, IsValidationError(ozzoError))
+	var ozzoErrors validation.Errors
+	assert.False(t, IsValidationError(ozzoErrors))
+	ozzoErrors = validation.Errors{"foo": ozzoError}
+	assert.True(t, IsValidationError(ozzoErrors))
+}

--- a/tests/mmock/config/test_sync_aws_iotcore/iotcore_get_policy.yml
+++ b/tests/mmock/config/test_sync_aws_iotcore/iotcore_get_policy.yml
@@ -1,0 +1,20 @@
+request:
+  description: Call to device auth for tenant "TenantSync01"
+  host: iot.region.amazonaws.com
+  method: GET
+  path: /policies/:policyName
+response:
+  statusCode: 200
+  headers:
+    Content-Type:
+      - "application/json"
+  body: |-
+    {
+        "creationDate": 1660042069,
+        "defaultVersionId": "1",
+        "generationId": "1234",
+        "lastModifiedDate": 1660069420,
+        "policyArn": "arn:aws:iot:region:1234567890:policy/{request.path.policyName}",
+        "policyDocument": "{}",
+        "policyName": "{request.path.policyName}"
+    }

--- a/tests/tests/test_sync_aws_iotcore.py
+++ b/tests/tests/test_sync_aws_iotcore.py
@@ -179,6 +179,22 @@ class TestSyncAWSIoTCore:
     expected_requests = [
         {
             "request": {
+                "host": "iot.region.amazonaws.com",
+                "method": "GET",
+                "path": "/policies/device-policy",
+            },
+            "result": {"match": True},
+        },
+        {
+            "request": {
+                "host": "iot.region.amazonaws.com",
+                "method": "GET",
+                "path": "/policies/device-policy",
+            },
+            "result": {"match": True},
+        },
+        {
+            "request": {
                 "host": "mender-device-auth",
                 "method": "GET",
                 "path": "/api/internal/v1/devauth/tenants/TestSyncAWSIoTCore01/devices",

--- a/tests/tests/utils.py
+++ b/tests/tests/utils.py
@@ -23,7 +23,7 @@ from datetime import datetime, timedelta
 
 def compare_expectations(expected, actual):
     for key, expected_value in expected.items():
-        assert key in actual
+        assert key in actual, f"key: '{key}' not in '{actual}'"
         actual_value = actual[key]
         if isinstance(expected_value, dict):
             compare_expectations(expected_value, actual_value)


### PR DESCRIPTION
Checks that the integration configuration has credentials that matches
the provider type and for AWS IoT Core integration, it also checks if
the device policy exists before accepting the configuration.

Changelog: Title
Ticket: None
Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>