### PR TITLE
chore(aws): Add AWS endpoint information to the device credentials

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -52,6 +52,7 @@ const (
 	confKeyPrimaryKey     = "azureConnectionString"
 	confKeyAWSCertificate = "awsCertificate"
 	confKeyAWSPrivateKey  = "awsPrivateKey"
+	confKeyAWSEndpoint    = "awsEndpoint"
 )
 
 // App interface describes app objects

--- a/app/app_iot_core.go
+++ b/app/app_iot_core.go
@@ -75,10 +75,11 @@ func (a *app) setDeviceStatusIoTCore(ctx context.Context, deviceID string, statu
 }
 
 func (a *app) deployConfiguration(ctx context.Context, deviceID string, dev *iotcore.Device) error {
-	if dev.Certificate != "" && dev.PrivateKey != "" {
+	if dev.Certificate != "" && dev.PrivateKey != "" && *dev.Endpoint != "" {
 		err := a.wf.ProvisionExternalDevice(ctx, deviceID, map[string]string{
 			confKeyAWSCertificate: dev.Certificate,
 			confKeyAWSPrivateKey:  dev.PrivateKey,
+			confKeyAWSEndpoint:    *dev.Endpoint,
 		})
 		if err != nil {
 			return errors.Wrap(err, "failed to submit iotcore credentials to deviceconfig")

--- a/app/app_iot_core_test.go
+++ b/app/app_iot_core_test.go
@@ -67,6 +67,7 @@ func TestProvisionDeviceIoTCore(t *testing.T) {
 
 		Error error
 	}
+	awsEndpoint := "test_aws_endpoint"
 	testCases := []testCase{
 		{
 			Name:     "ok",
@@ -99,6 +100,7 @@ func TestProvisionDeviceIoTCore(t *testing.T) {
 						ID:          self.DeviceID,
 						PrivateKey:  "private_key",
 						Certificate: "certificate",
+						Endpoint:    &awsEndpoint,
 					}, nil)
 				return core
 			},
@@ -110,6 +112,7 @@ func TestProvisionDeviceIoTCore(t *testing.T) {
 					map[string]string{
 						confKeyAWSPrivateKey:  "private_key",
 						confKeyAWSCertificate: "certificate",
+						confKeyAWSEndpoint:    awsEndpoint,
 					}).Return(nil)
 				return wf
 			},
@@ -203,6 +206,7 @@ func TestProvisionDeviceIoTCore(t *testing.T) {
 						ID:          self.DeviceID,
 						PrivateKey:  "private_key",
 						Certificate: "certificate",
+						Endpoint:    &awsEndpoint,
 					}, nil)
 				return core
 			},
@@ -214,6 +218,7 @@ func TestProvisionDeviceIoTCore(t *testing.T) {
 					map[string]string{
 						confKeyAWSPrivateKey:  "private_key",
 						confKeyAWSCertificate: "certificate",
+						confKeyAWSEndpoint:    awsEndpoint,
 					}).Return(errors.New("internal error"))
 				return wf
 			},
@@ -380,6 +385,7 @@ func TestSetDeviceStatusIoTCore(t *testing.T) {
 
 		Error error
 	}
+	awsEndpoint := "aws_endpoint"
 	testCases := []testCase{
 		{
 			Name: "ok",
@@ -403,8 +409,9 @@ func TestSetDeviceStatusIoTCore(t *testing.T) {
 			Core: func(t *testing.T, self *testCase) *coreMocks.Client {
 				core := new(coreMocks.Client)
 				dev := &iotcore.Device{
-					ID:     "foobar",
-					Status: iotcore.StatusDisabled,
+					ID:       "foobar",
+					Status:   iotcore.StatusDisabled,
+					Endpoint: &awsEndpoint,
 				}
 				core.On("UpsertDevice", contextMatcher, mock.AnythingOfType("model.AWSCredentials"), self.DeviceID,
 					mock.MatchedBy(func(dev *iotcore.Device) bool {
@@ -1049,11 +1056,12 @@ func TestSyncIoTCoreDevices(t *testing.T) {
 		},
 		Error: errors.New("internal error"),
 	}}
-	matchConf := func(cert, pkey string) func(map[string]string) bool {
+	matchConf := func(cert, pkey, endpoint string) func(map[string]string) bool {
 		return func(m map[string]string) bool {
 			return assert.Equal(t, map[string]string{
 				confKeyAWSCertificate: cert,
 				confKeyAWSPrivateKey:  pkey,
+				confKeyAWSEndpoint:    endpoint,
 			}, m)
 		}
 	}
@@ -1090,6 +1098,7 @@ func TestSyncIoTCoreDevices(t *testing.T) {
 						ID:     dev.ID,
 						Status: model.Status(*dev.DevauthStatus),
 					})
+					awsEndpoint := "test_aws_endpoint"
 					// Generate a random "Thing" identity
 					cert, pkey := createSelfSignedCertificate(dev.ID)
 					iotDev := iotcore.Device{
@@ -1098,6 +1107,7 @@ func TestSyncIoTCoreDevices(t *testing.T) {
 						CertificateID: uuid.NewString(),
 						Certificate:   string(cert),
 						PrivateKey:    string(pkey),
+						Endpoint:      &awsEndpoint,
 					}
 					if dev.CoreStatus != nil {
 						iotDev.Status = *dev.CoreStatus
@@ -1113,6 +1123,7 @@ func TestSyncIoTCoreDevices(t *testing.T) {
 						desiredStatus := iotcore.NewStatusFromMenderStatus(*dev.DevauthStatus)
 						desiredDev := iotDev
 						desiredDev.Status = desiredStatus
+						desiredDev.Endpoint = &awsEndpoint
 						if *dev.CoreStatus != desiredStatus {
 							// Status mismatch
 							core.On("UpsertDevice",
@@ -1131,6 +1142,7 @@ func TestSyncIoTCoreDevices(t *testing.T) {
 						}
 					} else {
 						iotDev.Status = iotcore.NewStatusFromMenderStatus(*dev.DevauthStatus)
+						iotDev.Endpoint = &awsEndpoint
 						// Provision device
 						core.On("GetDevice",
 							contextMatcher,
@@ -1150,7 +1162,7 @@ func TestSyncIoTCoreDevices(t *testing.T) {
 							wf.On("ProvisionExternalDevice",
 								contextMatcher,
 								dev.ID,
-								mock.MatchedBy(matchConf(iotDev.Certificate, iotDev.PrivateKey))).
+								mock.MatchedBy(matchConf(iotDev.Certificate, iotDev.PrivateKey, *iotDev.Endpoint))).
 								Return(nil).
 								Once()
 						}

--- a/client/iotcore/client_test.go
+++ b/client/iotcore/client_test.go
@@ -161,6 +161,7 @@ func TestUpsertDevice(t *testing.T) {
 	assert.NotEmpty(t, device.ID)
 	assert.NotEmpty(t, device.PrivateKey)
 	assert.NotEmpty(t, device.Certificate)
+	assert.NotEmpty(t, device.Endpoint)
 
 	device.Status = StatusEnabled
 	device, err = client.UpsertDevice(ctx, awsCredentials, deviceID, device, awsDevicePolicyName)

--- a/client/iotcore/model.go
+++ b/client/iotcore/model.go
@@ -23,13 +23,14 @@ import (
 )
 
 type Device struct {
-	ID            string `json:"id"`
-	Name          string `json:"name"`
-	Version       int64  `json:"version,omitempty"`
-	Status        Status `json:"status,omitempty"`
-	CertificateID string `json:"certificate_id,omitempty"`
-	Certificate   string `json:"certificate,omitempty"`
-	PrivateKey    string `json:"private_key,omitempty"`
+	ID            string  `json:"id"`
+	Name          string  `json:"name"`
+	Version       int64   `json:"version,omitempty"`
+	Status        Status  `json:"status,omitempty"`
+	CertificateID string  `json:"certificate_id,omitempty"`
+	Certificate   string  `json:"certificate,omitempty"`
+	PrivateKey    string  `json:"private_key,omitempty"`
+	Endpoint      *string `json:"endpoint,omitempty"`
 }
 
 type Status string


### PR DESCRIPTION
chore(aws): Add AWS endpoint information to the device credentials

Changelog: Title
Ticket: MEN-5778
Signed-off-by: Maciej Tomczuk <maciej.tomczuk@northern.tech>