### PR TITLE
refac(app): Move deviceGetter interface to separate file

### DIFF
--- a/app/device.go
+++ b/app/device.go
@@ -1,0 +1,62 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package app
+
+import (
+	"context"
+
+	"github.com/mendersoftware/iot-manager/model"
+
+	"github.com/google/uuid"
+)
+
+type deviceGetter interface {
+	GetDevice(context.Context, string) (*model.Device, error)
+}
+
+// device provides an interface to lazily load the device from the database
+// only when required.
+type device struct {
+	m            map[uuid.UUID]struct{}
+	err          error
+	DeviceID     string
+	DeviceGetter deviceGetter
+}
+
+func newDevice(deviceID string, deviceGetter deviceGetter) *device {
+	return &device{
+		DeviceID:     deviceID,
+		DeviceGetter: deviceGetter,
+	}
+}
+
+func (m *device) HasIntegration(ctx context.Context, id uuid.UUID) (bool, error) {
+	if m.err != nil {
+		return false, m.err
+	}
+	if m.m == nil {
+		dev, err := m.DeviceGetter.GetDevice(ctx, m.DeviceID)
+		if err != nil {
+			m.err = err
+			return false, m.err
+		}
+		m.m = make(map[uuid.UUID]struct{}, len(dev.IntegrationIDs))
+		for _, iid := range dev.IntegrationIDs {
+			m.m[iid] = struct{}{}
+		}
+	}
+	_, ret := m.m[id]
+	return ret, nil
+}

--- a/app/device_test.go
+++ b/app/device_test.go
@@ -1,0 +1,138 @@
+// Copyright 2022 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/mendersoftware/iot-manager/model"
+	storeMocks "github.com/mendersoftware/iot-manager/store/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+type testError struct{}
+
+func (testError) Error() string {
+	return "this is a test"
+}
+
+func TestDeviceHasIntegration(t *testing.T) {
+	t.Parallel()
+	var (
+		DeviceID      = uuid.NewString()
+		IntegrationID = uuid.New()
+	)
+	type testCase struct {
+		Name string
+
+		Init func(t *testing.T) (*device, *storeMocks.DataStore)
+
+		HasIntegration bool
+		Error          error
+	}
+
+	testCases := []testCase{{
+		Name: "ok",
+
+		Init: func(t *testing.T) (*device, *storeMocks.DataStore) {
+			getter := new(storeMocks.DataStore)
+			getter.On("GetDevice", contextMatcher, DeviceID).
+				Return(&model.Device{
+					ID: DeviceID,
+					IntegrationIDs: []uuid.UUID{
+						IntegrationID,
+					},
+				}, nil).
+				Once()
+			device := newDevice(DeviceID, getter)
+
+			return device, getter
+		},
+
+		HasIntegration: true,
+	}, {
+		// Should only call GetDevice once
+		Name: "ok/test twice",
+
+		Init: func(t *testing.T) (*device, *storeMocks.DataStore) {
+			getter := new(storeMocks.DataStore)
+			getter.On("GetDevice", contextMatcher, DeviceID).
+				Return(&model.Device{
+					ID: DeviceID,
+					IntegrationIDs: []uuid.UUID{
+						IntegrationID,
+					},
+				}, nil).
+				Once()
+			device := newDevice(DeviceID, getter)
+			has, err := device.HasIntegration(context.Background(), uuid.Nil)
+			assert.NoError(t, err)
+			assert.False(t, has)
+
+			return device, getter
+		},
+
+		HasIntegration: true,
+	}, {
+		Name: "error/GetDevice",
+
+		Init: func(t *testing.T) (*device, *storeMocks.DataStore) {
+			getter := new(storeMocks.DataStore)
+			getter.On("GetDevice", contextMatcher, DeviceID).
+				Return(nil, testError{}).
+				Once()
+			device := newDevice(DeviceID, getter)
+			return device, getter
+		},
+
+		Error: testError{},
+	}, {
+		Name: "error/multiple",
+
+		Init: func(t *testing.T) (*device, *storeMocks.DataStore) {
+			getter := new(storeMocks.DataStore)
+			getter.On("GetDevice", contextMatcher, DeviceID).
+				Return(nil, testError{}).
+				Once()
+			device := newDevice(DeviceID, getter)
+			_, err := device.HasIntegration(context.Background(), uuid.Nil)
+			assert.ErrorIs(t, err, testError{})
+
+			return device, getter
+		},
+
+		Error: testError{},
+	}}
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			dev, getter := tc.Init(t)
+			defer getter.AssertExpectations(t)
+
+			canIHaz, err := dev.HasIntegration(ctx, IntegrationID)
+			assert.Equal(t, tc.HasIntegration, canIHaz)
+			if tc.Error != nil {
+				assert.ErrorIs(t, err, tc.Error)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up from #81 