### PR TITLE
iot core client: wait for principal detachment to propagate when deleting device

### DIFF
--- a/client/iotcore/client_test.go
+++ b/client/iotcore/client_test.go
@@ -83,7 +83,7 @@ func init() {
 }
 
 func validAWSSettings(t *testing.T) bool {
-	if accessKeyID == "" || secretAccessKey == "" || awsRegion == "" {
+	if accessKeyID == "" || secretAccessKey == "" || awsRegion == "" || awsDevicePolicyName == "" {
 		t.Skip("AWS settings not provided or invalid")
 		return false
 	}

--- a/tests/tests/test_sync_aws_iotcore.py
+++ b/tests/tests/test_sync_aws_iotcore.py
@@ -246,12 +246,56 @@ class TestSyncAWSIoTCore:
         {
             "request": {
                 "host": "iot.region.amazonaws.com",
-                "method": "DELETE",
-                "path": "/things/7abb6133-ad97-44ba-a159-674242ee565e",
+                "method": "GET",
+                "path": "/things/7abb6133-ad97-44ba-a159-674242ee565e/principals",
             },
             "result": {
                 "match": True,
-                "uri": "test_sync_aws_iotcore/iotcore_delete_things.yml",
+                "uri": "test_sync_aws_iotcore/iotcore_list_things_principals_inactive_7abb6133-ad97-44ba-a159-674242ee565e.yml",
+            },
+        },
+        {
+            "request": {
+                "host": "iot.region.amazonaws.com",
+                "method": "GET",
+                "path": "/things/7abb6133-ad97-44ba-a159-674242ee565e/principals",
+            },
+            "result": {
+                "match": True,
+                "uri": "test_sync_aws_iotcore/iotcore_list_things_principals_inactive_7abb6133-ad97-44ba-a159-674242ee565e.yml",
+            },
+        },
+        {
+            "request": {
+                "host": "iot.region.amazonaws.com",
+                "method": "GET",
+                "path": "/things/7abb6133-ad97-44ba-a159-674242ee565e/principals",
+            },
+            "result": {
+                "match": True,
+                "uri": "test_sync_aws_iotcore/iotcore_list_things_principals_inactive_7abb6133-ad97-44ba-a159-674242ee565e.yml",
+            },
+        },
+        {
+            "request": {
+                "host": "iot.region.amazonaws.com",
+                "method": "GET",
+                "path": "/things/7abb6133-ad97-44ba-a159-674242ee565e/principals",
+            },
+            "result": {
+                "match": True,
+                "uri": "test_sync_aws_iotcore/iotcore_list_things_principals_inactive_7abb6133-ad97-44ba-a159-674242ee565e.yml",
+            },
+        },
+        {
+            "request": {
+                "host": "iot.region.amazonaws.com",
+                "method": "GET",
+                "path": "/things/7abb6133-ad97-44ba-a159-674242ee565e/principals",
+            },
+            "result": {
+                "match": True,
+                "uri": "test_sync_aws_iotcore/iotcore_list_things_principals_inactive_7abb6133-ad97-44ba-a159-674242ee565e.yml",
             },
         },
         {


### PR DESCRIPTION
Ticket: [MEN-6001](https://tracker.mender.io/browse/MEN-6001)
backport to mender 3.4 (iot core was not in the 3.3, so nothing more to do)
original PR: https://github.com/mendersoftware/iot-manager/pull/104 