### PR TITLE
fix: wrong capitalization for `Type`

### DIFF
--- a/client/iothub/model.go
+++ b/client/iothub/model.go
@@ -51,9 +51,8 @@ const (
 )
 
 type Auth struct {
-	Type            AuthType
-	*SymmetricKey   `json:"symmetricKey,omitempty"`
-	*X509ThumbPrint `json:"x509Thumbprint,omitempty"`
+	Type          AuthType `json:"type"`
+	*SymmetricKey `json:"symmetricKey,omitempty"`
 }
 
 func NewSymmetricAuth() (*Auth, error) {


### PR DESCRIPTION
IoT Hub APIs returns `400 Bad Request` if the authentication type's key is `Type`. It probably defaulted to `sas` before. We also remove `x509Thumbprint` from the model as our implementation is not compatible with it.

Changelog: Title
Ticket: QA-481

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>
(cherry picked from commit f8c0d0c3293c898c73316e04ec03f9df4428ab93)