### PR TITLE
chore: bump `requests` to version `2.31.0`

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,6 +9,7 @@ python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.15.1
 
-requests == 2.25.1
+docker == 6.1.3
+requests == 2.31.0
 chardet >= 4.0.0
 idna >= 2.10


### PR DESCRIPTION
Changelog: None
Ticket: None