### PR TITLE
test(accpetance): Infer Docker compose service name from host

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -13,7 +13,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-
 # tests are supposed to be located in the same directory as this file
 
 DIR=$(readlink -f $(dirname $0))
@@ -25,5 +24,6 @@ export PYTHONDONTWRITEBYTECODE=1
 pip3 install --quiet --force-reinstall -r /testing/requirements.txt
 
 py.test -vv -s --tb=short --verbose \
-        --junitxml=$DIR/results.xml \
-        $DIR/tests "$@"
+	--host="$TEST_HOST" \
+	--junitxml=$DIR/results.xml \
+	$DIR/tests "$@"

--- a/tests/tests/client.py
+++ b/tests/tests/client.py
@@ -33,25 +33,21 @@ from utils import generate_jwt
 class ManagementAPIClient(GenManagementAPIClient):
     def __init__(self, tenant_id, subject="tester"):
         jwt = generate_jwt(tenant_id, subject, is_user=True)
-        config = mgmt_Configuration(
-            host="http://mender-iot-manager:8080/api/management/v1/iot-manager",
-            access_token=jwt,
-        )
+        config = mgmt_Configuration.get_default_copy()
+        config.access_token = jwt
         client = mgmt_ApiClient(configuration=config)
         super().__init__(api_client=client)
 
 
 class InternalAPIClient(GenInternalAPIClient):
     def __init__(self):
-        config = intrnl_Configuration(
-            host="http://mender-iot-manager:8080/api/internal/v1/iot-manager",
-        )
+        config = intrnl_Configuration.get_default_copy()
         client = intrnl_ApiClient(configuration=config)
         super().__init__(api_client=client)
 
 
 class CliIoTManager:
-    def __init__(self):
+    def __init__(self, service="iot-manager"):
         self.docker = docker.from_env()
         _self = self.docker.containers.list(filters={"id": socket.gethostname()})[0]
 
@@ -60,7 +56,7 @@ class CliIoTManager:
             filters={
                 "label": [
                     f"com.docker.compose.project={project}",
-                    "com.docker.compose.service=mender-iot-manager",
+                    f"com.docker.compose.service={service}",
                 ]
             },
             limit=1,

--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -66,5 +66,5 @@ def clean_mongo(mongo):
 
 
 @pytest.fixture(scope="session")
-def cli_iot_manager():
-    return CliIoTManager()
+def cli_iot_manager(pytestconfig):
+    return CliIoTManager(pytestconfig.getoption("host").split(":")[0])


### PR DESCRIPTION
Remove hard-coded host name from config and actually use the `--host` pytest config.