### PR TITLE
fix(iot-core): Incosistent serialization format for device private key

### DIFF
--- a/crypto/csr.go
+++ b/crypto/csr.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"flag"
+	"fmt"
 )
 
 func NewPrivateKey() (*ecdsa.PrivateKey, error) {
@@ -32,10 +33,13 @@ func NewPrivateKey() (*ecdsa.PrivateKey, error) {
 	return privateKey, nil
 }
 
-func PrivateKeyToPem(privateKey *ecdsa.PrivateKey) []byte {
-	x509Encoded, _ := x509.MarshalECPrivateKey(privateKey)
+func PrivateKeyToPem(privateKey *ecdsa.PrivateKey) ([]byte, error) {
+	x509Encoded, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize private key: %w", err)
+	}
 	pemEncoded := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: x509Encoded})
-	return pemEncoded
+	return pemEncoded, nil
 }
 
 func NewCertificateSigningRequest(commonName string, key *ecdsa.PrivateKey) ([]byte, error) {

--- a/crypto/csr_test.go
+++ b/crypto/csr_test.go
@@ -24,9 +24,10 @@ func TestNewPrivateKey(t *testing.T) {
 	key, err := NewPrivateKey()
 	assert.NoError(t, err)
 
-	keyPem := string(PrivateKeyToPem(key))
-	assert.Contains(t, keyPem, "-----BEGIN PRIVATE KEY-----")
-	assert.Contains(t, keyPem, "-----END PRIVATE KEY-----")
+	keyPem, err := PrivateKeyToPem(key)
+	assert.NoError(t, err)
+	assert.Contains(t, string(keyPem), "-----BEGIN PRIVATE KEY-----")
+	assert.Contains(t, string(keyPem), "-----END PRIVATE KEY-----")
 }
 
 func TestNewCertificateSigningRequest(t *testing.T) {


### PR DESCRIPTION
The generated key is serialized using SEC 1 (RFC5915) ASN.1 encoding,
but encoded to PEM using PKCS8 (RFC5208) block header/trailer.